### PR TITLE
fix: get nonce in `getWalletNonce`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,7 @@ import { Peer } from "./types";
 export const getWalletNonce = async (peer: Peer, publicKey: string): Promise<number> => {
     try {
         const response = await http.get(`${getApiServerUrl(peer)}/api/wallets/${publicKey}`);
-        return parseInt(response.data.nonce ?? "0");
+        return parseInt(response.data.data.nonce ?? "0");
     } catch (err) {
         console.error(`Cannot find wallet by address ${publicKey}: ${err.message}`);
         throw err;


### PR DESCRIPTION
The nonce lookup is currently broken, always returning `0`.