### PR TITLE
fix: do not increment nonce in makeEvmDeploy

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -203,7 +203,7 @@ export const makeEvmDeploy = async (config: Config): Promise<Contracts.Crypto.Tr
         .gasPrice(evmDeploy.gasPrice)
         .payload(evmDeploy.data.slice(2))
         .gasLimit(2_000_000)
-        .nonce((walletNonce + 1).toString())
+        .nonce(walletNonce.toString())
         .vendorField(evmDeploy.vendorField);
 
     const signed = await builder.sign(senderPassphrase);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

this was causing the `EvmDeploy` call to provide in invalid nonce

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
