### PR TITLE
refactor: pad message fixture v signature

### DIFF
--- a/src/actions/generate-fixtures.ts
+++ b/src/actions/generate-fixtures.ts
@@ -176,7 +176,7 @@ const generateMessageSign = async (mnemonic: string) => {
     await writeFixtureToFile("message-sign.json", {
         message,
         publicKey,
-        signature: signature.r + signature.s + signature.v.toString(16),
+        signature: signature.r + signature.s + signature.v.toString(16).padStart(2, "0"),
     });
 };
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Noticed as part of https://app.clickup.com/t/86dx7bdvw - the message signature wasn't padding the `v` value

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
