### PR TITLE
refactor: adjust gas type in fixtures

### DIFF
--- a/src/actions/generate-fixtures.ts
+++ b/src/actions/generate-fixtures.ts
@@ -22,13 +22,22 @@ interface Identity {
 
 const writeFixtureToFile = async (filename: string, data: any) => {
     const dataDir = join(process.cwd(), "data");
+
+    if (data['data'] && typeof data['data']['gasPrice'] !== 'undefined') {
+        data['data']['gasPrice'] = data['data']['gasPrice'].toString();
+    }
+
+    if (data['data'] && typeof data['data']['gasLimit'] !== 'undefined') {
+        data['data']['gasLimit'] = data['data']['gasLimit'].toString();
+    }
+
     try {
-        writeFileSync(join(dataDir, filename), JSON.stringify(data, null, 2));
+        writeFileSync(join(dataDir, filename), JSON.stringify(data, null, 4));
     } catch (error) {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") {
             const { mkdirSync } = await import("fs");
             mkdirSync(dataDir, { recursive: true });
-            writeFileSync(join(dataDir, filename), JSON.stringify(data, null, 2));
+            writeFileSync(join(dataDir, filename), JSON.stringify(data, null, 4));
         } else {
             throw error;
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The typescript-crypto package requires a string or BigNumber for `gasPrice` and `gasLimit`. This PR adjusts the fixture generation so they are a string as default, to save having to change them to a string when updating them.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
